### PR TITLE
Document AGA8 single-phase limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ More examples are provided in the examples folder: https://github.com/equinor/pv
 - **Thermodynamics**: Thermodynamic functions
 - **Fluid Mechanics**: Fluid mechanic functions
 - **Metering**: Metering functions
-- **aga8**: Equations for calculating gas properties (GERG-2008 and DETAIL) using the Rust port (https://crates.io/crates/aga8) of NIST's AGA8 code (https://github.com/usnistgov/AGA8)
+- **aga8**: Equations for calculating gas properties (GERG-2008 and DETAIL) using the Rust port (https://crates.io/crates/aga8) of NIST's AGA8 code (https://github.com/usnistgov/AGA8). **Note: AGA8 is only valid for single-phase gas conditions. It does not check for phase state and will produce erroneous results in the two-phase or liquid region.**
 - **Unit converters**: Functions to convert between different units of measure
 - **Equipment**:
   - **Compressors**: Compressor performance calculations (e.g. polytropic exponent, polytropic head and efficiency)

--- a/examples/01 Gas Properties from AGA8/README.md
+++ b/examples/01 Gas Properties from AGA8/README.md
@@ -2,6 +2,8 @@
 
 This example demonstrates how to calculate gas properties using the AGA8 equations of state (GERG-2008 and DETAIL implementations).
 
+> **Note:** AGA8 is only valid for single-phase gas conditions. It does not check for phase state and will produce erroneous results if used in the two-phase or liquid region. Ensure the operating conditions are within the single-phase gas region before using these calculations.
+
 ## Description
 
 The example shows how to:

--- a/examples/05 Gas Properties from Measured SOS/README.md
+++ b/examples/05 Gas Properties from Measured SOS/README.md
@@ -2,6 +2,8 @@
 
 This example demonstrates how to calculate gas properties (density, molar mass, compressibility factor) from a measured speed of sound value.
 
+> **Note:** These calculations rely on AGA8 (GERG-2008/DETAIL), which is only valid for single-phase gas conditions. AGA8 does not check for phase state and will produce erroneous results if the operating point is in the two-phase or liquid region.
+
 ## Description
 
 The example shows two approaches:

--- a/pvtlib/aga8.py
+++ b/pvtlib/aga8.py
@@ -42,6 +42,12 @@ class AGA8:
         Calculate gas properties using pressure, temperature, and composition as input.
     calculate_from_rhoT(composition, mass_density, temperature, temperature_unit='C', molar_mass=None)
         Calculate gas properties using mass density, temperature, and composition as input.
+
+    .. warning::
+        AGA8 is only valid for single-phase gas conditions. It does not check for phase state
+        and will produce erroneous results if applied in the two-phase or liquid region.
+        The user is responsible for ensuring that the operating conditions are within the
+        single-phase gas region before using these calculations.
     
     References
     ----------
@@ -193,6 +199,11 @@ class AGA8:
             Molar mass can be given as an optional input [kg/kmol]. If this is given, this molar mass will be used to calculate the mass density instead of the AGA8 calculated molar mass. 
             The default is None. In that case the AGA8 calculated molar mass will be used.
 
+        Notes
+        -----
+        Only valid for single-phase gas conditions. Results will be erroneous if the
+        operating point falls within the two-phase or liquid region. No phase check is performed.
+
         Returns
         -------
         results : TYPE
@@ -291,6 +302,11 @@ class AGA8:
         molar_mass : float, optional
             Molar mass can be given as an optional input [kg/kmol]. If this is given, this molar mass will be used to calculate the mass density instead of the AGA8 calculated molar mass. The default is None. In that case the AGA8 calculated molar mass will be used. 
         
+        Notes
+        -----
+        Only valid for single-phase gas conditions. Results will be erroneous if the
+        operating point falls within the two-phase or liquid region. No phase check is performed.
+
         Returns
         -------
         results : dict
@@ -372,7 +388,13 @@ class AGA8:
         pressure_unit : str, optional
             The unit of the pressure, by default 'bara'.
         molar_mass : float, optional
-            The molar mass of the gas mixture, by default None. If None, the AGA8 molar mass is used. 
+            The molar mass of the gas mixture, by default None. If None, the AGA8 molar mass is used.
+
+        Notes
+        -----
+        Only valid for single-phase gas conditions. Results will be erroneous if the
+        operating point falls within the two-phase or liquid region. No phase check is performed.
+
         Returns
         -------
         results : dict
@@ -426,7 +448,13 @@ class AGA8:
         pressure_unit : str, optional
             The unit of the pressure, by default 'bara'.
         molar_mass : float, optional
-            The molar mass of the gas mixture, by default None. If None, the AGA8 molar mass is used. 
+            The molar mass of the gas mixture, by default None. If None, the AGA8 molar mass is used.
+
+        Notes
+        -----
+        Only valid for single-phase gas conditions. Results will be erroneous if the
+        operating point falls within the two-phase or liquid region. No phase check is performed.
+
         Returns
         -------
         results : dict

--- a/pvtlib/thermodynamics.py
+++ b/pvtlib/thermodynamics.py
@@ -309,6 +309,11 @@ def properties_from_sos_kappa(gas_composition, measured_sos, pressure_bara, temp
     EOS : str, optional
         Equation of state to use. Either 'GERG-2008' or 'DETAIL'. Default is 'GERG-2008'.
 
+    Notes
+    -----
+    Only valid for single-phase gas conditions. AGA8 does not check for phase state and
+    will produce erroneous results if the operating point is in the two-phase or liquid region.
+
     Returns
     -------
     output : dict


### PR DESCRIPTION
Add warnings and Notes clarifying that AGA8 (GERG-2008/DETAIL) is only valid for single-phase gas conditions and does not perform phase checks. Updated README.md and two example READMEs to surface the limitation, and added docstring warnings/Notes in pvtlib/aga8.py and pvtlib/thermodynamics.py. Documentation-only change; no functional behavior was modified.