### PR TITLE
Bump version to 1.14.3 and update pyaga8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pvtlib"
-version = "1.14.2"
+version = "1.14.3"
 authors = [
     {name = "Christian Hågenvik", email = "chaagen2013@gmail.com"},
 ]
@@ -21,7 +21,7 @@ classifiers = [
 dependencies = [
     "numpy>=1.26.2",
     "scipy>=1.11.4",
-    "pyaga8>=0.1.15",
+    "pyaga8>=0.1.16",
 ]
 
 [project.urls]


### PR DESCRIPTION
Update pyproject.toml: bump package version to 1.14.3 and raise the pyaga8 dependency to >=0.1.16 to align with the updated dependency release and prepare the next package release.

The reason for the update was because the pyaga8 dependency did not automatically build wheel files for python 3.14. This is now fixed. 