### PR TITLE
Fix for Variable defined multiple times

### DIFF
--- a/pvtlib/unit_converters.py
+++ b/pvtlib/unit_converters.py
@@ -95,10 +95,6 @@ def barg_to_Pa(barg, P_atm=1.01325):
     return Pa
 
 
-def barg_to_kPa(barg:float, atm=1.01325):
-    return (barg + atm) * 10 ** 5 / 1000
-
-
 def Pa_to_barg(Pa, P_atm=1.01325):
     barg = (Pa/100000)-P_atm
     return barg


### PR DESCRIPTION
To fix this without changing functionality, remove the first (earlier) `barg_to_kPa` definition at lines 98–99 and keep the later definition at lines 116–119 as the single source of truth.

Best approach here:
- Edit `pvtlib/unit_converters.py`.
- Delete the earlier duplicate:
  - `def barg_to_kPa(barg:float, atm=1.01325):`
  - `    return (barg + atm) * 10 ** 5 / 1000`
- Leave the later `barg_to_kPa(barg, P_atm=1.01325)` untouched.

This resolves the redundant assignment warning and preserves current effective behavior (since the later definition is already the one actually used).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._