### PR TITLE
Patch 2

### DIFF
--- a/pvtlib/equipment/compressors.py
+++ b/pvtlib/equipment/compressors.py
@@ -288,16 +288,16 @@ def flow_coeff(Q, N, D, DefType='MAN'):
     if DefType not in valid_types:
         raise ValueError(f"DefType must be one of {valid_types}, got '{DefType}'")
     
+    # Convert to arrays for consistent handling
+    Q = np.asarray(Q, dtype=float)
+    N = np.asarray(N, dtype=float)
+    D = np.asarray(D, dtype=float)
+
     # Calculate numerator based on definition type
     if DefType == 'MAN':
         numerator = Q
     elif DefType == 'ISO 5389':
         numerator = 4 * Q
-    
-    # Convert to arrays for consistent handling
-    Q = np.asarray(Q, dtype=float)
-    N = np.asarray(N, dtype=float)
-    D = np.asarray(D, dtype=float)
     
     # Calculate denominator
     U = D * np.pi * N / 60  # Tip speed

--- a/pvtlib/metering/differential_pressure_flowmeters.py
+++ b/pvtlib/metering/differential_pressure_flowmeters.py
@@ -120,6 +120,7 @@ def calculate_flow_venturi(D, d, dP, rho1, C=None, epsilon=None, check_input=Fal
         - 'Velocity': Flow velocity [m/s].
         - 'C': Discharge coefficient used.
         - 'epsilon': Expansion factor used.
+        - 'beta': Diameter ratio (d/D).
 
     Raises
     ------
@@ -137,7 +138,8 @@ def calculate_flow_venturi(D, d, dP, rho1, C=None, epsilon=None, check_input=Fal
         'VolFlow': np.nan,
         'Velocity': np.nan,
         'C': np.nan,
-        'epsilon': np.nan
+        'epsilon': np.nan,
+        'beta': np.nan
         }
     
     if check_input:
@@ -178,9 +180,10 @@ def calculate_flow_venturi(D, d, dP, rho1, C=None, epsilon=None, check_input=Fal
         rho1=rho1
         )
 
-    # Return epsilon used and discharge coefficient used
+    # Return epsilon used, discharge coefficient used, and beta
     results['C'] = C_used
     results['epsilon'] = epsilon_used
+    results['beta'] = beta
 
     return results
 

--- a/tests/test_aga8.py
+++ b/tests/test_aga8.py
@@ -643,8 +643,8 @@ def test_mix_performance():
     
     # Use a mix of different complexities
     gas_A = {'N2': 2, 'C1': 90, 'C2': 5, 'C3': 3}
-    gas_B = {'N2': 100}
-    gas_C = {'CO2': 50, 'C1': 50}
+    # gas_B = {'N2': 100}
+    # gas_C = {'CO2': 50, 'C1': 50}
     gas_D = {'N2': 10, 'C1': 80, 'C2': 5, 'C3': 5}
     
     # Warm up (ensure AGA8 is fully initialized)

--- a/tests/test_differential_pressure_flowmeters.py
+++ b/tests/test_differential_pressure_flowmeters.py
@@ -79,7 +79,7 @@ def test_V_cone_calculation_1():
         dP=dP,
         rho1=14.35,
         C = 0.8259,
-        epsilon = epsilon
+        epsilon=epsilon
         )
     
     #Calculate relative deviation [%] in mass flow from reference
@@ -96,15 +96,15 @@ def test_V_cone_calculation_2():
     criteria = 0.1 # [%] Calculations resulted in 0.05% deviation from the value in datasheet due to number of decimals
     
     dP = 71.66675
-    epsilon = 0.9809
+    epsilon = 0.99212
     
     res = differential_pressure_flowmeters.calculate_flow_V_cone(
         D=0.024,  
         beta=0.55, 
         dP=dP,
         rho1=0.362,
-        C = 0.8389,
-        epsilon = 0.99212
+        C=0.8389,
+        epsilon=epsilon
         )
     
     #Calculate relative deviation [%] in mass flow from reference
@@ -149,8 +149,6 @@ def test_calculate_expansibility_Stewart_V_cone():
     '''
     
     beta = differential_pressure_flowmeters.calculate_beta_V_cone(D=0.073406, dc=0.0586486)
-    
-    criteria = 0.003 # %
     
     epsilon = differential_pressure_flowmeters.calculate_expansibility_Stewart_V_cone(
         beta=beta, 


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the compressor and differential pressure flowmeter modules, as well as their associated tests. The main changes include enhanced handling of input types in the compressor flow coefficient calculation, the addition of the diameter ratio (`beta`) to venturi flowmeter results, and updates to test values and comments for improved clarity and correctness.

**Differential Pressure Flowmeter Enhancements:**

* The `calculate_flow_venturi` function now includes the diameter ratio (`beta`) in its returned results dictionary, providing more comprehensive output for users. [[1]](diffhunk://#diff-df7997f13236e6c07c1766841ff27b1f20628be711a4e6efa75ca7e76888f7d1R123) [[2]](diffhunk://#diff-df7997f13236e6c07c1766841ff27b1f20628be711a4e6efa75ca7e76888f7d1L140-R142) [[3]](diffhunk://#diff-df7997f13236e6c07c1766841ff27b1f20628be711a4e6efa75ca7e76888f7d1L181-R186)

**Compressor Module Improvements:**

* In `flow_coeff`, conversion of `Q`, `N`, and `D` to NumPy arrays is now performed before any calculations, ensuring consistent handling of both scalar and array inputs.

**Test Updates and Maintenance:**

* Commented out definitions for `gas_B` and `gas_C` in `test_mix_performance` to clean up unused variables and clarify test intentions.
* Updated the `epsilon` value in `test_V_cone_calculation_2` to reflect a more accurate or current reference value.
* Removed an unused `criteria` variable in `test_calculate_expansibility_Stewart_V_cone` for code cleanliness.