### PR TITLE
Cleanup: remove unused imports/vars in tests/examples

### DIFF
--- a/examples/09 Gas Density Meter Corrections/gas_density_meter_corrections.py
+++ b/examples/09 Gas Density Meter Corrections/gas_density_meter_corrections.py
@@ -37,8 +37,6 @@ from pvtlib.metering.gas_density_meters import (
     GDM_uncorr_dens,
     GDM_tempcorr_dens,
     GDM_SOScorr_dens,
-    GDM_Q,
-    gas_spesific_gravity
 )
 from pvtlib import AGA8
 

--- a/tests/test_aga8.py
+++ b/tests/test_aga8.py
@@ -655,7 +655,7 @@ def test_mix_performance():
     start_time = time.perf_counter()
     
     for _ in range(n_iterations):
-        result = aga8.mix([gas_A, gas_D], [50, 50])
+        _result = aga8.mix([gas_A, gas_D], [50, 50]) #_result is kept for debug purposes
     
     end_time = time.perf_counter()
     elapsed_time = end_time - start_time

--- a/tests/test_differential_pressure_flowmeters.py
+++ b/tests/test_differential_pressure_flowmeters.py
@@ -543,8 +543,6 @@ def test_calculate_flow_orifice_without_C():
     criteria = 0.0001 # [%] Allowable deviation
 
     for case, case_dict in cases.items():
-        # Calculate orifice beta
-        beta = differential_pressure_flowmeters.calculate_beta_DP_meter(D=case_dict['D'], d=case_dict['d'])
 
         res = differential_pressure_flowmeters.calculate_flow_orifice(
             D=case_dict['D'],


### PR DESCRIPTION
Remove unused imports (GDM_Q, gas_spesific_gravity) from gas_density_meter_corrections example; change result -> _result in test_aga8 loop (kept for debug) to avoid unused-variable warnings; remove redundant beta calculation lines from test_differential_pressure_flowmeters. These are small cleanups to remove dead code and silence linters.