### PR TITLE
Patch 4

### DIFF
--- a/pvtlib/unit_converters.py
+++ b/pvtlib/unit_converters.py
@@ -21,6 +21,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+import math
 
 # Temperature
 def celsius_to_kelvin(celsius):
@@ -372,11 +373,6 @@ def microOhm_to_Ohm(microOhm):
     return Ohm
 
 
-def microOhm_to_Ohm_new(microOhm):
-    Ohm = microOhm/1000000
-    return Ohm
-
-
 def VA_to_kVA(VA):
     kVA = VA/1000
     return kVA
@@ -481,11 +477,11 @@ def milesPerHour_to_metersPerSecond(milesPerHour):
 
 
 def radians_to_degrees(radians):
-    degrees = radians*180/3.14159265359
+    degrees = radians*180/math.pi
     return degrees
 
 def degrees_to_radians(degrees):
-    radians = degrees/180*3.14159265359
+    radians = degrees/180*math.pi
     return radians
 
 

--- a/tests/test_differential_pressure_flowmeters.py
+++ b/tests/test_differential_pressure_flowmeters.py
@@ -205,7 +205,7 @@ def test_calculate_beta_DP_meter():
     assert differential_pressure_flowmeters.calculate_beta_DP_meter(D=0.2, d=0.05)==0.25, 'Beta calculation failed'
 
 
-def test_calculate_expansibility_ventiruri():
+def test_calculate_expansibility_venturi():
     '''
     The function has been tested on a number of known cases. 
     Then these test cases have been generated, to cover a wider range of possible inputs.

--- a/tests/test_unit_converters.py
+++ b/tests/test_unit_converters.py
@@ -305,10 +305,6 @@ def test_microOhm_to_Ohm():
     assert microOhm_to_Ohm(1000000) == 1
     assert microOhm_to_Ohm(0) == 0
 
-def test_microOhm_to_Ohm_new():
-    assert microOhm_to_Ohm_new(1000000) == 1
-    assert microOhm_to_Ohm_new(0) == 0
-
 def test_VA_to_kVA():
     assert VA_to_kVA(1000) == 1
     assert VA_to_kVA(0) == 0


### PR DESCRIPTION
This pull request makes several minor improvements and cleanups to the unit conversion utilities and associated tests. The main changes include fixing a function name typo in a test, improving the accuracy of angle conversions by using the `math` module, and removing redundant code.

**Improvements to unit conversion accuracy:**

* Updated `radians_to_degrees` and `degrees_to_radians` in `unit_converters.py` to use `math.pi` for more precise calculations, and imported the `math` module as required. [[1]](diffhunk://#diff-ade150329df80bbbeaf86b54502b18ad628041933d18e16851d8615afd08c6f1R24) [[2]](diffhunk://#diff-ade150329df80bbbeaf86b54502b18ad628041933d18e16851d8615afd08c6f1L484-R484)

**Code cleanup and test maintenance:**

* Removed the redundant `microOhm_to_Ohm_new` function and its associated test, as the original `microOhm_to_Ohm` function suffices. [[1]](diffhunk://#diff-ade150329df80bbbeaf86b54502b18ad628041933d18e16851d8615afd08c6f1L375-L379) [[2]](diffhunk://#diff-98694137776705e4d87d99ae1e94c80c2c8a34eeb35633cae1c545e7687b3950L308-L311)

**Test corrections:**

* Fixed a typo in the test function name from `test_calculate_expansibility_ventiruri` to `test_calculate_expansibility_venturi` for consistency and correctness.