### PR TITLE
Align Python support metadata

### DIFF
--- a/.github/workflows/python-package-run-tests.yml
+++ b/.github/workflows/python-package-run-tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-package-run-tests.yml
+++ b/.github/workflows/python-package-run-tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,14 +11,16 @@ authors = [
 description = "A library containing various tools in the categories of thermodynamics, fluid mechanics, metering etc."
 readme = "README.md"
 license = {text = "MIT"}
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 keywords = ["thermodynamics", "fluid-mechanics", "metering", "aga8"]
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,14 @@ authors = [
 description = "A library containing various tools in the categories of thermodynamics, fluid mechanics, metering etc."
 readme = "README.md"
 license = {text = "MIT"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 keywords = ["thermodynamics", "fluid-mechanics", "metering", "aga8"]
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]


### PR DESCRIPTION
Align declared and tested Python support to Python 3.10-3.13 so repository metadata, CI, and the PyPI Python versions badge stay consistent.