### PR TITLE
chore: bump pyaga8 to 0.1.17 and release 1.14.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pvtlib"
-version = "1.14.4"
+version = "1.14.5"
 authors = [
     {name = "Christian Hågenvik", email = "chaagen2013@gmail.com"},
 ]
@@ -27,7 +27,7 @@ classifiers = [
 dependencies = [
     "numpy>=1.26.2",
     "scipy>=1.11.4",
-    "pyaga8>=0.1.16",
+    "pyaga8>=0.1.17",
 ]
 
 [project.urls]


### PR DESCRIPTION
This pull request makes minor updates to the `pyproject.toml` file, including a version bump for the `pvtlib` package and an updated dependency requirement for `pyaga8`.

- Versioning:
  * Bumped the `pvtlib` package version from `1.14.4` to `1.14.5`.

- Dependency updates:
  * Updated the `pyaga8` dependency requirement from `>=0.1.16` to `>=0.1.17`.